### PR TITLE
Allow reading final template in YAML instead.

### DIFF
--- a/formica/cli.py
+++ b/formica/cli.py
@@ -76,7 +76,7 @@ def template(yml):
     """Print the current template"""
     loader = Loader()
     loader.load()
-    if yaml:
+    if yml:
         click.echo(
             loader.template(
                 dumper=functools.partial(yaml.safe_dump, default_flow_style=False)

--- a/formica/cli.py
+++ b/formica/cli.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
+import yaml
 import click
 import logging
+import functools
 from texttable import Texttable
 
 from formica import CHANGE_SET_FORMAT
@@ -69,11 +71,19 @@ def main(debug):
 
 
 @main.command()
-def template():
+@click.option('--yml/--no-yml', default=False, help='Output in YAML instead')
+def template(yml):
     """Print the current template"""
     loader = Loader()
     loader.load()
-    click.echo(loader.template())
+    if yaml:
+        click.echo(
+            loader.template(
+                dumper=functools.partial(yaml.safe_dump, default_flow_style=False)
+            ).strip()  # strip trailing newline to avoid blank line in output
+        )
+    else:
+        click.echo(loader.template())
 
 
 @main.command()

--- a/formica/loader.py
+++ b/formica/loader.py
@@ -81,7 +81,9 @@ class Loader(object):
     def render(self, filename, **args):
         return self.env.get_template(filename).render(code=self.include_file, **args)
 
-    def template(self, indent=4, sort_keys=True, separators=(',', ': ')):
+    def template(self, indent=4, sort_keys=True, separators=(',', ': '), dumper=None):
+        if dumper is not None:
+            return dumper(self.cftemplate)
         return json.dumps(self.cftemplate, indent=indent, sort_keys=sort_keys, separators=separators)
 
     def template_dictionary(self):


### PR DESCRIPTION
Adds a `--yml` option to `formica template` to make it easier to
manually the template built by showing it as YAML instead of JSON.