### PR TITLE
Remove indents for templates near the max length

### DIFF
--- a/formica/cli.py
+++ b/formica/cli.py
@@ -210,7 +210,7 @@ def template(args):
             ).strip()  # strip trailing newline to avoid blank line in output
         )
     else:
-        logger.info(loader.template())
+        logger.info(loader.template(indent=4))
 
 
 def stacks(args):
@@ -269,8 +269,8 @@ def change(args):
     loader.load()
 
     change_set = ChangeSet(stack=args.stack, client=client)
-    change_set.create(template=loader.template(), change_set_type='UPDATE', parameters=args.parameters, tags=args.tags,
-                      capabilities=args.capabilities)
+    change_set.create(template=loader.template(indent=None), change_set_type='UPDATE', parameters=args.parameters,
+                      tags=args.tags, capabilities=args.capabilities)
     change_set.describe()
 
 
@@ -299,8 +299,8 @@ def new(args):
     loader.load()
     logger.info('Creating change set for new stack, ...')
     change_set = ChangeSet(stack=args.stack, client=client)
-    change_set.create(template=loader.template(), change_set_type='CREATE', parameters=args.parameters, tags=args.tags,
-                      capabilities=args.capabilities)
+    change_set.create(template=loader.template(indent=None), change_set_type='CREATE', parameters=args.parameters,
+                      tags=args.tags, capabilities=args.capabilities)
     change_set.describe()
     logger.info('Change set created, please deploy')
 

--- a/formica/loader.py
+++ b/formica/loader.py
@@ -85,7 +85,11 @@ class Loader(object):
     def template(self, indent=4, sort_keys=True, separators=(',', ': '), dumper=None):
         if dumper is not None:
             return dumper(self.cftemplate)
-        return json.dumps(self.cftemplate, indent=indent, sort_keys=sort_keys, separators=separators)
+        tpl = json.dumps(self.cftemplate, indent=indent, sort_keys=sort_keys, separators=separators)
+        if len(tpl) > 51200:
+            # CloudFormation's max template length limit is 51200 chars, as of November 2017
+            return json.dumps(self.cftemplate, sort_keys=sort_keys, separators=separators)
+        return tpl
 
     def template_dictionary(self):
         return self.cftemplate

--- a/formica/loader.py
+++ b/formica/loader.py
@@ -85,11 +85,7 @@ class Loader(object):
     def template(self, indent=4, sort_keys=True, separators=(',', ': '), dumper=None):
         if dumper is not None:
             return dumper(self.cftemplate)
-        tpl = json.dumps(self.cftemplate, indent=indent, sort_keys=sort_keys, separators=separators)
-        if len(tpl) > 51200:
-            # CloudFormation's max template length limit is 51200 chars, as of November 2017
-            return json.dumps(self.cftemplate, sort_keys=sort_keys, separators=separators)
-        return tpl
+        return json.dumps(self.cftemplate, indent=indent, sort_keys=sort_keys, separators=separators)
 
     def template_dictionary(self):
         return self.cftemplate

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -307,10 +307,10 @@ def test_code_includes_supports_nested_code_arguments(load, tmpdir):
     assert actual == {"Description": "nested-test"}
 
 
-def test_un_indents_large_templates(load, tmpdir):
+def test_un_indented_large_templates(load):
     # Generate a large dictionary that, with indent=4, is too large to deploy
-    # as a template. Loader supports autodetection of too-long templates and
-    # removes indentation.
+    # as a template. Loader supports passing the `indent` param as `None` to
+    # remove indentation.
     load.cftemplate = {'Resources': {i: 'a' * 84 for i in range(512)}}
-    assert len(json.dumps(load.cftemplate, indent=4)) > 51200
-    assert len(load.template()) < 51200
+    assert len(load.template()) > 51200
+    assert len(load.template(indent=None)) < 51200

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -305,3 +305,12 @@ def test_code_includes_supports_nested_code_arguments(load, tmpdir):
         load.load()
         actual = json.loads(load.template())
     assert actual == {"Description": "nested-test"}
+
+
+def test_un_indents_large_templates(load, tmpdir):
+    # Generate a large dictionary that, with indent=4, is too large to deploy
+    # as a template. Loader supports autodetection of too-long templates and
+    # removes indentation.
+    load.cftemplate = {'Resources': {i: 'a' * 84 for i in range(512)}}
+    assert len(json.dumps(load.cftemplate, indent=4)) > 51200
+    assert len(load.template()) < 51200


### PR DESCRIPTION
Indenting 4 characters can make templates too big for the normal
CloudFormation size limit. One example I have is a template that
(without indents) is 20684 characters expands to 51312 characters with
the formica 4-char default indentation. For reference, the YAML
representation of the same template is 24082, so based on my sample of 1
template the most efficient representation is non-indented JSON.

This change adds a check when returning a JSONified template that it's
under the CloudFormation length limit.