### PR TITLE
Parse command line arguments as yaml values

### DIFF
--- a/formica/cli.py
+++ b/formica/cli.py
@@ -40,7 +40,7 @@ class SplitEqualsAction(argparse.Action):
             try:
                 for string in values:
                     key, value = string.split('=', 2)
-                    parameters[key] = value
+                    parameters[key] = yaml.load(value)
                     setattr(namespace, self.dest, parameters)
             except ValueError:
                 raise argparse.ArgumentError(self, '%r needs to be in format KEY=VALUE' % string)


### PR DESCRIPTION
This would allow to pass variables such as `["item1", "item2"]` on the command line.

Right now, if you call `formica template --vars var1='["item1", "item2"]'`, var1 will be parsed as a string. With this change it would be parsed as a list.

The same happens with dictionaries: `--vars dict1='{"key": "value"}'`. 

The behaviour stays the same if the variables are strings.