### PR TITLE
Merge config file arguments with ones from the command line

### DIFF
--- a/formica/cli.py
+++ b/formica/cli.py
@@ -327,12 +327,16 @@ def load_config_file(args, config_file):
         key = key.replace('-', '_')
         if key in CONFIG_FILE_ARGUMENTS.keys():
             config_type = CONFIG_FILE_ARGUMENTS[key]
-            if not args_dict.get(key) and value:
-                if isinstance(value, config_type):
-                    args_dict[key] = value
+            if isinstance(value, config_type):
+                if config_type == dict and args_dict.get(key):
+                    merged = value
+                    merged.update(args_dict[key])
+                    args_dict[key] = merged
                 else:
-                    logger.error('Config file parameter {} needs to be of type {}'.format(key, config_type.__name__))
-                    sys.exit(2)
+                    args_dict[key] = value
+            else:
+                logger.error('Config file parameter {} needs to be of type {}'.format(key, config_type.__name__))
+                sys.exit(2)
         else:
             logger.error('Config file parameter {} is not supported'.format(key))
             sys.exit(2)


### PR DESCRIPTION
Right now, if you use a configuration file to set some variables, all the variables passed through the command line are ignored.

With this change, it would be possible to define some variables in the configuration file and some others through the command line.

There is a small detail: with my change if you have a variable defined in both places, the one from the command line has precedence. Should I keep it like this?