### PR TITLE
GetAtt: Split into two values at most (more cause errors)

### DIFF
--- a/formica/yaml_tags.py
+++ b/formica/yaml_tags.py
@@ -36,7 +36,7 @@ for function in fn_functions:
 class SplitFunction(BaseFunction):
     @classmethod
     def from_yaml(cls, loader, node):
-        return ({cls.fn_tag(node.tag): node.value.split('.')})
+        return ({cls.fn_tag(node.tag): node.value.split('.', 1)})
 
 
 split_functions = [

--- a/tests/unit/test_yaml_tags.py
+++ b/tests/unit/test_yaml_tags.py
@@ -32,6 +32,7 @@ def runner(loader, tmpdir):
     ('Resources: !FindInMap [ RegionMap, !Ref "A", 32 ]',
      {'Resources': {"Fn::FindInMap": ['RegionMap', {"Ref": "A"}, 32]}}),
     ('Resources: !GetAtt A.B', {'Resources': {"Fn::GetAtt": ['A', 'B']}}),
+    ('Resources: !GetAtt A.B.C', {'Resources': {"Fn::GetAtt": ['A', 'B.C']}}),
     ('Resources: !GetAZs us-east-1', {'Resources': {"Fn::GetAZs": 'us-east-1'}}),
     ('Resources: !ImportValue ABC', {'Resources': {"Fn::ImportValue": 'ABC'}}),
     ('Resources: !Join ["", "A", "B"]', {'Resources': {"Fn::Join": ['', 'A', 'B']}}),


### PR DESCRIPTION
Splitting into more than 2 values will create errors by cloudformation, e.g. to retrieve the port of an RDS::DBInstance, the correct way is (note the `.` in the field parameter):

```json
{ "Port": { "Fn::GetAtt": [ "MyDatabase", "Endpoint.Port"] } }
```

Functions like `!GetAtt MyDatabase.Endpoint.Port` will thus yield the correct value